### PR TITLE
~ fix re-preprocessing bug

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -78,6 +78,9 @@
     }
 
     preprocess(input) {
+      if ('@context' in input) {
+        return "input preprocessed";
+      }
       let resourceType;
       if (input.resourceType) {
         resourceType = parseResourceType(input.resourceType);


### PR DESCRIPTION
An active R4 or R5 tab with already-pre-processed input displays "input preprocessed" rather than throwing an error